### PR TITLE
Fixed catch-all exception handler

### DIFF
--- a/Prac1/template.py
+++ b/Prac1/template.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         print("Exiting gracefully")
         # Turn off your GPIOs here
         GPIO.cleanup()
-    except e:
+    except Exception as e:
         GPIO.cleanup()
         print("Some other error occurred")
         print(e.message)


### PR DESCRIPTION
The general case for catching all exceptions was not working because the exception variable e was not defined, this was hiding the actual error as all errors became "NameError: name 'e' is not defined" on line 37

The fix was to add the base exception class "Exception"